### PR TITLE
Reduce looping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,145 +10,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "const_fn"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
-dependencies = [
- "cfg-if",
- "const_fn",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
-dependencies = [
- "autocfg",
- "cfg-if",
- "lazy_static",
-]
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
-
-[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
-
-[[package]]
-name = "memoffset"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "rayon"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
-dependencies = [
- "autocfg",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "lazy_static",
- "num_cpus",
-]
 
 [[package]]
 name = "regex"
@@ -169,12 +40,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +52,5 @@ dependencies = [
 name = "twograms"
 version = "0.1.0"
 dependencies = [
- "rayon",
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 
 [dependencies]
 regex = "1"
-rayon = "1.5"
+# rayon = "1.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,31 +2,6 @@
 use rayon::prelude::*;
 use regex::Regex;
 use std::collections::HashMap;
-use std::fmt;
-
-pub struct WordPredictions {
-    word: String,
-    predictions: Vec<(String, usize)>,
-}
-
-static SEPARATOR: char = '§';
-
-impl fmt::Display for WordPredictions {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let predictions = self
-            .predictions
-            .iter()
-            .map(|p| format!("{} ({})", p.0, p.1))
-            .collect::<Vec<String>>()
-            .join(", ");
-        write!(f, "Word: *{}*. Predictions: {}", self.word, predictions,)
-    }
-}
-struct WordScore {
-    word: String,
-    second_word: String,
-    score: usize,
-}
 
 pub fn parse_file(s: &str) -> Vec<String> {
     println!("Parsing a file of {} characters", s.len());
@@ -43,75 +18,28 @@ pub fn parse_file(s: &str) -> Vec<String> {
         .collect()
 }
 
-pub fn get_wordpredictions(words: &[String]) -> HashMap<String, WordPredictions> {
-    let unique_words = get_unique_words(&words);
-    let two_grams = generate_scores(&words);
-    predictions_to_wordprediction_hashmap(unique_words, two_grams)
-}
-
-fn generate_scores(words: &[String]) -> Vec<WordScore> {
+fn generate_scores(words: &[String]) -> HashMap<(String, String), usize> {
     println!("Generating scores for {} sequences", words.len());
-    let mut prediction_map: HashMap<String, usize> = HashMap::new();
+    let mut prediction_map: HashMap<(String, String), usize> = HashMap::new();
     words
         .windows(2)
-        .map(|pair| format!("{}{}{}", pair[0], SEPARATOR, pair[1]))
-        .for_each(|key| *prediction_map.entry(key).or_insert(0) += 1);
-    // At least only do this ONCE
+        .for_each(|pair| {
+            *prediction_map
+                .entry((pair[0].clone(), pair[1].clone()))
+                .or_insert(0) += 1;
+        });
     prediction_map
-        .iter()
-        .map(prediction_tuple_to_word_score)
-        .collect()
 }
 
-fn prediction_tuple_to_word_score(item: (&String, &usize)) -> WordScore {
-    let mut split = item.0.split(SEPARATOR);
-    let word = split.next().unwrap().to_string();
-    let second_word = split.next().unwrap().to_string();
-    WordScore {
-        word,
-        second_word,
-        score: *item.1,
+fn group_wordpredictions(predictions_hm: HashMap<(String, String), usize>) -> HashMap<String, Vec<(String, usize)>> {
+    let mut hm: HashMap<String, Vec<(String, usize)>> = HashMap::new();
+    for ((first_word, second_word), score) in predictions_hm {
+        let entry = hm
+            .entry(first_word)
+            .or_insert(vec![]);
+        entry.push((second_word, score));
     }
-}
-
-fn get_unique_words(words: &[String]) -> Vec<String> {
-    println!("Deduping {} words", words.len());
-    let mut words_sorted = words.to_owned();
-    words_sorted.sort_unstable();
-    words_sorted.dedup();
-    words_sorted
-}
-
-fn predictions_to_wordprediction_hashmap(
-    unique_words: Vec<String>,
-    predictions: Vec<WordScore>,
-) -> HashMap<String, WordPredictions> {
-    println!(
-        "Generating word predictions for {} words",
-        unique_words.len()
-    );
-    unique_words
-        .par_iter()
-        .map(|first_word| {
-            let word_grouped = group_word_scores(first_word, &predictions);
-            (first_word.to_string(), word_grouped)
-        })
-        .collect()
-}
-
-fn group_word_scores(first_word: &str, predictions: &[WordScore]) -> WordPredictions {
-    let mut second_word_scores: Vec<&WordScore> = predictions
-        .iter()
-        .filter(|word_score| word_score.word == *first_word)
-        .collect();
-    second_word_scores.sort_by(|a, b| b.score.cmp(&a.score));
-    WordPredictions {
-        word: first_word.to_string(),
-        predictions: second_word_scores
-            .iter()
-            .map(|word_score| (word_score.second_word.clone(), word_score.score))
-            .collect(),
-    }
+    hm
 }
 
 #[cfg(test)]
@@ -129,12 +57,10 @@ mod tests {
     #[test]
     fn test_alice() {
         let words = parse_file(include_str!("alice.txt"));
-        let unique_words = get_unique_words(&words);
-        let two_grams = generate_scores(&words);
-        let word_predictions = predictions_to_wordprediction_hashmap(unique_words, two_grams);
+        let scores = generate_scores(&words);
+        let word_predictions = group_wordpredictions(scores);
         let word_a = word_predictions.get("a").unwrap();
-        assert_eq!(word_a.word, "a");
-        assert_eq!(word_a.predictions.len(), 37);
+        assert_eq!(word_a.len(), 37);
         assert_eq!(word_predictions.len(), 610);
     }
 
@@ -142,9 +68,9 @@ mod tests {
     fn test_bible_parser() {
         let words = parse_file(include_str!("10900-8.txt"));
         assert_eq!(words.len(), 858338);
-        let word_predictions = get_wordpredictions(&words);
+        let scores = generate_scores(&words);
+        let word_predictions = group_wordpredictions(scores);
         let word_a = word_predictions.get("a").unwrap();
-        assert_eq!(word_a.word, "a");
-        assert_eq!(word_a.predictions.len(), 1335);
+        assert_eq!(word_a.len(), 1335);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(map_into_keys_values)]
-use rayon::prelude::*;
 use regex::Regex;
 use std::collections::HashMap;
 


### PR DESCRIPTION
Before:

```
running 3 tests
test tests::test_parse_file ... ok
test tests::test_alice ... ok
test tests::test_bible_parser ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 27.22s
```


After:
```
    Finished test [unoptimized + debuginfo] target(s) in 0.00s
     Running target/debug/deps/twograms-90f691ec9ea2d25b

running 3 tests
test tests::test_parse_file ... ok
test tests::test_alice ... ok
test tests::test_bible_parser ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.39s
```